### PR TITLE
OZ-557: Add documentation for data flows between OpenMRS and ERPNext.

### DIFF
--- a/docs/users/emr-erp.md
+++ b/docs/users/emr-erp.md
@@ -66,7 +66,7 @@ flowchart LR
 
 :construction: tbc
 
-## Data Flows between OpenMRS and ERPNext
+## Data Flows between ERPNext and OpenMRS 
 
 ### OpenMRS Patient → ERPNext Customer
 
@@ -85,14 +85,16 @@ None
 
 #### Options
 
-!!! note "Override Default Behavior"
+=== "Behaviour"
 
-    Take control of your settings! Override the default options by supplying your custom configurations in the `ozone/distro/configs/eip-erpnext-openmrs/application.properties` file.
+    - <small>**default**</small> &nbsp; An OpenMRS patient is synchronised as an ERPNext customer when a first billable item is ordered from OpenMRS.
+    - <small>_optional_</small> &nbsp; An OpenMRS patient is always synchronised as an ERPNext customer.
 
+=== "Configuration"
 
-| Property Name                         | Description                                                                                                                                                                                                                                                                                                                                                                                                   | Default Value |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `erpnext.openmrs.enable.patient.sync` | Controls the automatic synchronization of patients from OpenMRS to ERPNext. When this property is set to `true`, a patient record created in OpenMRS is immediately mirrored as a customer record in ERPNext. If this property is set to `false`, the default behavior is followed, which is to create a customer record in ERPNext only when the first billable item for the patient is recorded in OpenMRS. | `false`       |
+    - File:<br/>`ozone/distro/configs/eip-erpnext-openmrs/application.properties`
+    - Property name:<br/>`erpnext.openmrs.enable.patient.sync`
+    - Possible values:<br/>`false` (<small>**default**</small>), `true`
 
 ### OpenMRS Billable Items ⭆ ERPNext Quotation
 
@@ -119,7 +121,7 @@ None
 ### OpenMRS Billable Item → ERPNext Quotation Line
 
 #### Summary
-Each billable item ordered in OpenMRS for a patient is synchronized as a quotation item in the corresponding customer's draft ERPNext quotation.
+Each billable item ordered in OpenMRS for a patient is synchronized in ERPNext as a quotation item in the corresponding customer's draft quotation.
 
 #### Main Flow
 ``` mermaid
@@ -146,9 +148,9 @@ None
 
 #### Summary
 As soon as the first billable item is ordered for a patient in OpenMRS,
-a draft quotation is created in ERPNext based on the Patient's Visit.
+a draft quotation is created in ERPNext based on the patient's visit.
 When the visit is ended, the quotation is submitted.
-Following submission, the quotation is eligible for conversion into a Sales Order.
+Following submission, the quotation is eligible for conversion into a sales order.
 
 #### Main Flow
 ``` mermaid

--- a/docs/users/emr-erp.md
+++ b/docs/users/emr-erp.md
@@ -17,7 +17,7 @@ flowchart LR
 
 None
 
-#### Configurability
+#### Options
 
 :construction: tbc
 
@@ -36,7 +36,7 @@ flowchart LR
 
 - [OpenMRS patient → Odoo customer](#openmrs-patient-odoo-customer)
 
-#### Configurability
+#### Options
 
 None
 
@@ -62,6 +62,104 @@ flowchart LR
 - [OpenMRS patient → Odoo customer](#openmrs-patient-odoo-customer)
 - [OpenMRS billable item ⭆ Odoo quotation](#openmrs-billable-items-odoo-quotation)
 
-#### Configurability
+#### Options
 
 :construction: tbc
+
+## Data Flows between OpenMRS and ERPNext
+
+### OpenMRS Patient → ERPNext Customer
+
+#### Summary
+A patient in OpenMRS is synchronized as a customer in ERPNext.
+
+#### Main Flow
+``` mermaid
+flowchart LR
+    a["OpenMRS patient"]-- 1-to-1 -->b["ERPNext customer"]
+```
+
+#### Prerequisite Flows
+
+None
+
+#### Options
+
+!!! note "Override Default Behavior"
+
+    Take control of your settings! Override the default options by supplying your custom configurations in the `ozone/distro/configs/eip-erpnext-openmrs/application.properties` file.
+
+
+| Property Name                         | Description                                                                                                                                                                                                                                                                                                                                                                                                   | Default Value |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `erpnext.openmrs.enable.patient.sync` | Controls the automatic synchronization of patients from OpenMRS to ERPNext. When this property is set to `true`, a patient record created in OpenMRS is immediately mirrored as a customer record in ERPNext. If this property is set to `false`, the default behavior is followed, which is to create a customer record in ERPNext only when the first billable item for the patient is recorded in OpenMRS. | `false`       |
+
+### OpenMRS Billable Items ⭆ ERPNext Quotation
+
+#### Summary
+As soon as the first billable item is ordered for a patient in OpenMRS,
+a quotation is created in ERPNext for the corresponding customer.
+Billable items ordered in the same visit are added to the same quotation as quotation items.
+
+#### Main Flow
+``` mermaid
+flowchart LR
+    a["OpenMRS billable items"]-- many-to-1 -->b["ERPNext quotation"]
+```
+
+#### Prerequisite Flows
+
+- [OpenMRS patient → ERPNext customer](#openmrs-patient-erpnext-customer)
+- [OpenMRS Visit → ERPNext Quotation](#openmrs-visit-erpnext-quotation)
+
+#### Options
+
+None
+
+### OpenMRS Billable Item → ERPNext Quotation Line
+
+#### Summary
+Each billable item ordered in OpenMRS for a patient is synchronized as a quotation item in the corresponding customer's draft ERPNext quotation.
+
+#### Main Flow
+``` mermaid
+flowchart LR
+    a["OpenMRS billable item"]-- 1-to-1 -->b["ERPNext quotation Item"]
+```
+
+#### Billable Items
+
+- Drug order
+- Lab test order
+- Service order
+
+#### Prerequisite Flows
+
+- [OpenMRS patient → ERPNext customer](#openmrs-patient-erpnext-customer)
+- [OpenMRS Visit → ERPNext Quotation](#openmrs-visit-erpnext-quotation)
+
+#### Options
+
+None
+
+### OpenMRS Visit → ERPNext Quotation
+
+#### Summary
+As soon as the first billable item is ordered for a patient in OpenMRS,
+a draft quotation is created in ERPNext based on the Patient's Visit.
+When the visit is ended, the quotation is submitted.
+Following submission, the quotation is eligible for conversion into a Sales Order.
+
+#### Main Flow
+``` mermaid
+flowchart LR
+    a["OpenMRS visit"]-- 1-to-1 -->b["ERPNext quotation"]
+```
+
+#### Prerequisite Flows
+
+- [OpenMRS patient → ERPNext customer](#openmrs-patient-erpnext-customer)
+
+#### Options
+
+None

--- a/docs/users/emr-erp.md
+++ b/docs/users/emr-erp.md
@@ -99,9 +99,11 @@ None
 ### OpenMRS Billable Items ⭆ ERPNext Quotation
 
 #### Summary
-As soon as the first billable item is ordered for a patient in OpenMRS,
-a quotation is created in ERPNext for the corresponding customer.
-Billable items ordered in the same visit are added to the same quotation as quotation items.
+As soon
+as the first billable item is ordered for a patient in OpenMRS a quotation is created in ERPNext for the corresponding customer,
+and the quotation is associated with the OpenMRS patient's visit.
+All billable items ordered for a patient within the same OpenMRS visit are added to the ERPNext quotation
+associated with this OpenMRS visit.
 
 #### Main Flow
 ``` mermaid
@@ -147,10 +149,7 @@ None
 ### OpenMRS Visit → ERPNext Quotation
 
 #### Summary
-As soon as the first billable item is ordered for a patient in OpenMRS,
-a draft quotation is created in ERPNext based on the patient's visit.
-When the visit is ended, the quotation is submitted.
-Following submission, the quotation is eligible for conversion into a sales order.
+Ending a patient's visit in OpenMRS submits the ERPNext quotation associated with this visit.
 
 #### Main Flow
 ``` mermaid
@@ -161,6 +160,7 @@ flowchart LR
 #### Prerequisite Flows
 
 - [OpenMRS patient → ERPNext customer](#openmrs-patient-erpnext-customer)
+- [OpenMRS Billable Items ⭆ ERPNext Quotation](#openmrs-billable-items-erpnext-quotation)
 
 #### Options
 


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-557

This PR adds documentation for the data flows between OpenMRS and ERPNext. It includes the main flows, prerequisite flows, and options for each data flow. The data flows documented are:

- OpenMRS Patient → ERPNext Customer
- OpenMRS Billable Items ⭆ ERPNext Quotation
- OpenMRS Billable Item → ERPNext Quotation Line
- OpenMRS Visit → ERPNext Quotation