### PR TITLE
Enhance Keycloak theming documentation with detailed customization guidelines

### DIFF
--- a/docs/implementers/branding-apps.md
+++ b/docs/implementers/branding-apps.md
@@ -107,79 +107,142 @@ Let's say you want to change the navbar background color to dark blue and button
 
 ## White-labelling Keycloak
 
-Keycloak allows you to fully customize its look, feel, and behavior by modifying its themes. Themes control how pages like login, account management, and email templates appear to users.
+Keycloak controls how several pages look and behave, like the login page, the account page, and password emails. You can change all of these by using Keycloak themes.
 
-### Types of Keycloak Theme Pages
+### Types of Keycloak theme pages
 
-Keycloak has different pages and templates which can be customized:
+Keycloak has different pages and templates you can customize:
 
-- *Login Pages*
-- *Account Pages*
-- *Admin Console Pages*
+- *Login pages*
+- *Account pages*
+- *Admin console pages*
 - *Email templates*
 
-!!! tip "Recommendation"
+!!! tip "Always extend, don't start from scratch"
 
-      Keycloak supports **theme inheritance**, which means you can extend an existing theme and override only the parts you need. Unless you plan to replace every single page, you should extend another theme instead of starting from scratch.
+    Keycloak supports **theme inheritance**. A theme can set a `parent`, and it automatically gets everything from that parent theme. You only need to add the small bits you actually want to change. Unless you plan to replace every single page, extend an existing theme instead of building a new one from scratch.
 
-### Customization Methods
+### Ozone's built-in login theme
 
-There are several ways to customize themes in Keycloak. The two most recommended methods are:
+Ozone ships its own login theme, called `ozone`, at [`distro/configs/keycloak/themes/ozone`](https://github.com/ozone-his/ozone/tree/main/distro/configs/keycloak/themes/ozone). It only changes branding: colors, the logo, the font, and the "powered by" logos row. Everything else, like page layout, forms, and error pages, comes straight from Keycloak's own built-in `keycloak.v2` theme, so it keeps working when Keycloak is upgraded.
 
-#### - Freemarker Templates (.ftl files)
+Every Ozone child distribution already uses this theme by default. In most cases, you don't need to build a Keycloak theme at all. Your own theme just needs a `theme.properties` file that says:
 
-**Technology**: Uses [Apache FreeMarker](https://freemarker.apache.org/)    
-**Use Case**: Good for small customizations or branding changes  
-**Used In**:
+```properties
+parent=ozone
+```
 
-- [Ozone Distro](https://github.com/ozone-his/ozone/tree/main/distro/configs/keycloak/themes/carbon/login) - A custom login screen for Ozone, implemented using FTL templates and custom CSS.
-- [OpenMRS Distro HIS](https://github.com/openmrs/openmrs-distro-his/tree/main/configs/keycloak/themes/carbon/login) - Customized login screen for OpenMRS Distro HIS
+This means your theme automatically gets everything from `ozone` (colors, logo, font, powered by logos, all its layout fixes) unless you override it. To customize something, add only the file or property for that one thing. Everything you don't touch keeps coming from `ozone`.
 
-**How to use**:
+#### Change the brand color and logo
 
-- Follow the official Keycloak documentation on [creating a theme](https://www.keycloak.org/docs/latest/server_development/index.html#creating-a-theme).
-- Once your theme directory (e.g., `myCustomTheme`) is ready, place it inside the `configs/keycloak/themes` folder in your Ozone distribution.
-- The Maven build process will automatically detect the theme and load it into Keycloak.
-- After the Ozone distribution is up and running:
-    - Log in to Keycloak.
-    - Navigate to the Themes section.
-    - Select your custom theme.
-    - Restart the Keycloak container if required.
-- To make this your **default** theme:
-    - Duplicate the realm configuration file in your distribution.
-    - Place the copy inside the `configs/keycloak/realms` folder.
-- In the copied file, update the Keycloak theme name at [this location](https://github.com/ozone-his/ozone/blob/main/distro/configs/keycloak/realms/ozone-realm.json#L1917).
+Add your own `login/resources/css/branding.css` file, and update your theme's `theme.properties` to include it:
 
+```properties
+styles=css/styles.css vendor/patternfly-v5/patternfly.min.css vendor/patternfly-v5/patternfly-addons.css css/branding.css
+```
 
-#### - Keycloakify
+```css
+/* login/resources/css/branding.css */
+:root {
+  --pf-v5-global--primary-color--100: #YOUR-COLOR;
+  --keycloak-card-top-color: #YOUR-COLOR;
+  --keycloak-logo-url: url("../img/logo.png");
+}
 
-**Technology**: React-based theme builder [Keycloakify](https://www.keycloakify.dev/)  
-**Use Case**: Ideal for complex UI changes and building modern UIs  
-**Used In**: 
+.pf-v5-c-button {
+  --pf-v5-c-button--m-primary--BackgroundColor: #YOUR-COLOR;
+}
+```
 
-- Ozone FAIMER Project - Used to fully customize login, reset password, and email verification pages.
+Then put your own `logo.png` in `login/resources/img/`.
 
-**How to use**:
+Keycloak doesn't merge the `styles` list across parent themes, so you need to repeat the full list and add your own CSS file at the end. Putting it last means your colors win over the ones already set in `ozone`.
 
-- Follow the Keycloakify documentation on [theme types](https://docs.keycloakify.dev/theme-types/difference-between-login-themes-and-the-other-types-of-themes).
-- Make the desired cosmetic changes to your theme.
-- [Build your theme JAR](https://docs.keycloakify.dev/deploying-your-theme#building-the-jar-file).
-- You now have two deployment options:
-    - **Mavenize the Keycloakify project** and publish the JAR to a central repository so it can be pulled into your distribution automatically.
-    - **Manually deploy** by building the JAR locally and copying it into the distribution every time you make a theme change.
-- In either case, ensure the following:
-    - The JAR should end up in `distro/binaries/keycloak/themes` in your final distribution package.
-    - If manually copying, place the JAR directly inside `binaries/keycloak/themes` in your distribution.
-- To make this your **default** theme:
-    - Duplicate the realm configuration file in your distribution.
-    - Place the copy inside `configs/keycloak/realms`.
+#### Change the "powered by" logos
 
+This one is the easiest. You don't need any CSS or template file at all. Just add this line to your theme's `theme.properties`:
 
-### Additional Notes
+```properties
+poweredByLogos=your-logo.png:An Organization, another-logo.svg:Another App
+```
 
-!!! warning "Important Considerations"
+Each logo is written as `filename:Alt Text`, separated by commas. Put the actual image files in `login/resources/img/`.
 
-      - Always test your theme against compatible Keycloak version
-      - Keycloakify themes are compiled using a Node.js build toolchain
-      - FTL themes are simpler to implement but offer less flexibility compared to React-based solutions
+To hide the "powered by" row completely, set it to an empty value:
 
+```properties
+poweredByLogos=
+```
+
+#### Change the login page text
+
+Add a `login/messages/messages_en.properties` file, and only include the keys you want to change, for example:
+
+```properties
+poweredBy=Brought to you by
+```
+
+Any key you don't mention still comes from the `ozone` theme, or from Keycloak itself.
+
+!!! warning "Don't copy the theme's files"
+
+    Don't copy `ozone`'s `footer.ftl`, `theme.properties`, or `branding.css` into your own theme and edit the copy. You will lose future fixes made to the `ozone` theme, and it defeats the point of inheriting from it. Only add the small file or property for the one thing you want to change.
+
+### Building a theme from scratch (advanced)
+
+If you need to change more than branding, for example the page structure or the fields on a form, you can build a full custom Keycloak theme. There are two common ways to do this.
+
+#### Freemarker templates (.ftl files)
+
+**Technology**: [Apache FreeMarker](https://freemarker.apache.org/)  
+**Use case**: Small customizations, or full control over the page HTML  
+**Used in**:
+
+- Ozone's own [`ozone` theme](https://github.com/ozone-his/ozone/tree/main/distro/configs/keycloak/themes/ozone)
+- [OpenMRS Distro HIS](https://github.com/openmrs/openmrs-distro-his/tree/main/configs/keycloak/themes/carbon/login)
+
+**How to use it**:
+
+1. Follow the official Keycloak documentation on [creating a theme](https://www.keycloak.org/docs/latest/server_development/index.html#creating-a-theme). Set `parent=keycloak.v2` (or `parent=ozone`, see above) so you only need to override what you actually want to change.
+2. Place your theme folder inside `configs/keycloak/themes` in your distribution.
+3. Rebuild your distribution. Your theme will be picked up automatically.
+4. To use it, set it as the `loginTheme` in your realm file. In Ozone's own realm file, this is at [this location](https://github.com/ozone-his/ozone/blob/main/distro/configs/keycloak/realms/ozone-realm.json#L1917). If you don't want to edit the main realm file directly, copy it into your own distribution's `configs/keycloak/realms` folder and change the copy instead.
+
+!!! tip "Alternative: set the theme from the admin console"
+
+    Instead of editing the realm file, you can also set the theme from the Keycloak Admin Console:
+
+    1. Log in to the Keycloak Admin Console and pick Ozone realm.
+    2. Go to **Realm settings > Themes**.
+    3. Choose your theme from the **Login theme** dropdown.
+    4. Click **Save**.
+
+    This is a quick way to try out a theme without rebuilding your distribution. But it only changes what is stored in Keycloak's database. If your realm file ever gets re-imported (for example on a fresh install, or in another environment), that import will not know about this change. To make your theme the real default everywhere, still set `loginTheme` in your realm file as well.
+
+!!! warning "Avoid full page rewrites"
+
+    Don't override a whole page template, like `template.ftl` or `login.ftl`, unless you truly need to change its structure. A full rewrite only styles the one page you wrote, so every other Keycloak page (register, forgot password, errors) can end up looking broken or inconsistent. Change only the small piece you need instead, like one CSS file, one message, or the `footer.ftl` file.
+
+#### Keycloakify
+
+**Technology**: React-based theme builder, [Keycloakify](https://www.keycloakify.dev/)  
+**Use case**: Complex UI changes, or building a fully custom, modern UI  
+**Used in**: Ozone FAIMER Project, to fully customize the login, reset password, and email verification pages.
+
+**How to use it**:
+
+1. Follow the Keycloakify documentation on [theme types](https://docs.keycloakify.dev/theme-types/difference-between-login-themes-and-the-other-types-of-themes).
+2. Make your changes, then [build your theme JAR](https://docs.keycloakify.dev/deploying-your-theme#building-the-jar-file).
+3. Add the JAR to your distribution in one of two ways:
+    - **Mavenize the Keycloakify project** and publish the JAR so it gets pulled into your distribution automatically.
+    - **Copy the JAR manually** into `distro/binaries/keycloak/themes` each time you make a change.
+4. To use it, set it as the `loginTheme` in your realm file, the same way as described above.
+
+### A few things to keep in mind
+
+!!! warning "Important considerations"
+
+    - Always test your theme against the Keycloak version you are running. Themes can break between major versions.
+    - Keycloakify themes need a Node.js build step.
+    - FTL themes are simpler to build, but give you less flexibility than a React based theme.

--- a/docs/implementers/branding-apps.md
+++ b/docs/implementers/branding-apps.md
@@ -107,7 +107,7 @@ Let's say you want to change the navbar background color to dark blue and button
 
 ## White-labelling Keycloak
 
-Keycloak controls how several pages look and behave, like the login page, the account page, and password emails. You can change all of these by using Keycloak themes.
+Keycloak controls how several pages look and behave, like the login page, the account page, admin console, and email templates. You can change all of these by using Keycloak themes.
 
 ### Types of Keycloak theme pages
 


### PR DESCRIPTION
This PR rewrites and expands the Keycloak theming and branding documentation for Ozone distributions. The new version clarifies the recommended approach (theme inheritance), explains how to make common branding changes without duplicating files, and gives step-by-step guides for both simple and advanced customizations. It also adds practical warnings and tips to help implementers avoid common pitfalls.